### PR TITLE
Creating gate plots 

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,16 +57,12 @@
         }
         .plot-container {
             margin-bottom: 20px;
-            position: relative;
-            height: 300px;
-            width: 100%;
         }
         #plotCanvas, #gateKineticsCanvas {
-            width: 100% !important;
-            height: 100% !important;
-            position: absolute;
-            left: 0;
-            top: 0;
+            width: 800px;
+            height: 300px;
+            border: 1px solid #ccc;
+            margin-bottom: 20px;
         }
         .tab-buttons {
             display: flex;

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,10 +55,13 @@
         .param-input {
             flex: 1;
         }
-        #plotCanvas {
+        #plotCanvas, #gateKineticsCanvas {
             width: 100%;
-            height: 400px;
+            height: 300px;
             border: 1px solid #ccc;
+            margin-bottom: 20px;
+        }
+        .plot-container {
             margin-bottom: 20px;
         }
         .tab-buttons {
@@ -189,7 +192,12 @@
         </div>
 
         <div id="plotContainer">
-            <canvas id="plotCanvas"></canvas>
+            <div class="plot-container">
+                <canvas id="plotCanvas"></canvas>
+            </div>
+            <div class="plot-container">
+                <canvas id="gateKineticsCanvas"></canvas>
+            </div>
         </div>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,14 +55,18 @@
         .param-input {
             flex: 1;
         }
-        #plotCanvas, #gateKineticsCanvas {
-            width: 100%;
-            height: 300px;
-            border: 1px solid #ccc;
-            margin-bottom: 20px;
-        }
         .plot-container {
             margin-bottom: 20px;
+            position: relative;
+            height: 300px;
+            width: 100%;
+        }
+        #plotCanvas, #gateKineticsCanvas {
+            width: 100% !important;
+            height: 100% !important;
+            position: absolute;
+            left: 0;
+            top: 0;
         }
         .tab-buttons {
             display: flex;

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,10 +59,9 @@
             margin-bottom: 20px;
         }
         #plotCanvas, #gateKineticsCanvas {
-            width: 800px;
-            height: 300px;
             border: 1px solid #ccc;
             margin-bottom: 20px;
+            /* Width and height are now handled in JavaScript */
         }
         .tab-buttons {
             display: flex;

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -4,6 +4,8 @@ class PlotManager {
         this.gateKineticsChart = null;
         this.voltageCanvasId = null;
         this.gateKineticsCanvasId = null;
+        this.canvasWidth = 800;  // Store canvas dimensions as class properties
+        this.canvasHeight = 300;
         this.varList = [
             'm', 'h', 'n',
             'I_Na (uA)', 'I_K (uA)', 'g_Na (uS)',
@@ -47,18 +49,20 @@ class PlotManager {
         this.voltageCanvasId = voltageCanvasId;
         this.gateKineticsCanvasId = gateKineticsCanvasId;
 
+        // Get canvas elements
         const voltageCanvas = document.getElementById(voltageCanvasId);
         const gateKineticsCanvas = document.getElementById(gateKineticsCanvasId);
 
-        // Explicitly set canvas dimensions from CSS or desired fixed size
-        // Ensure this matches your CSS, or set your desired fixed size directly here.
-        const canvasWidth = 800; // As per your CSS
-        const canvasHeight = 300; // As per your CSS
-
-        voltageCanvas.width = canvasWidth;
-        voltageCanvas.height = canvasHeight;
-        gateKineticsCanvas.width = canvasWidth;
-        gateKineticsCanvas.height = canvasHeight;
+        // Set both the canvas dimensions and style dimensions to ensure proper scaling
+        voltageCanvas.width = this.canvasWidth;
+        voltageCanvas.height = this.canvasHeight;
+        voltageCanvas.style.width = `${this.canvasWidth}px`;
+        voltageCanvas.style.height = `${this.canvasHeight}px`;
+        
+        gateKineticsCanvas.width = this.canvasWidth;
+        gateKineticsCanvas.height = this.canvasHeight;
+        gateKineticsCanvas.style.width = `${this.canvasWidth}px`;
+        gateKineticsCanvas.style.height = `${this.canvasHeight}px`;
 
         const commonXAxisConfig = {
             type: 'linear',
@@ -184,16 +188,20 @@ class PlotManager {
         const voltageParent = document.getElementById(this.voltageCanvasId).parentNode;
         const newVoltageCanvas = document.createElement('canvas');
         newVoltageCanvas.id = this.voltageCanvasId;
-        newVoltageCanvas.width = 800; // Match CSS
-        newVoltageCanvas.height = 300; // Match CSS
+        newVoltageCanvas.width = this.canvasWidth;
+        newVoltageCanvas.height = this.canvasHeight;
+        newVoltageCanvas.style.width = `${this.canvasWidth}px`;
+        newVoltageCanvas.style.height = `${this.canvasHeight}px`;
         voltageParent.innerHTML = ''; // Clear old canvas if any remnants
         voltageParent.appendChild(newVoltageCanvas);
 
         const gateParent = document.getElementById(this.gateKineticsCanvasId).parentNode;
         const newGateCanvas = document.createElement('canvas');
         newGateCanvas.id = this.gateKineticsCanvasId;
-        newGateCanvas.width = 800; // Match CSS
-        newGateCanvas.height = 300; // Match CSS
+        newGateCanvas.width = this.canvasWidth;
+        newGateCanvas.height = this.canvasHeight;
+        newGateCanvas.style.width = `${this.canvasWidth}px`;
+        newGateCanvas.style.height = `${this.canvasHeight}px`;
         gateParent.innerHTML = ''; // Clear old canvas
         gateParent.appendChild(newGateCanvas);
 

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -65,6 +65,7 @@ class PlotManager {
                 responsive: true,
                 maintainAspectRatio: false,
                 animation: false,
+                resizeDelay: 0,
                 scales: {
                     x: {
                         type: 'linear',
@@ -89,11 +90,10 @@ class PlotManager {
                         ticks: {
                             stepSize: 20
                         },
-                        grace: '5%',
-                        beginAtZero: false,
-                        adapative: false,
-                        suggestedMin: this.voltageYMin,
-                        suggestedMax: this.voltageYMax
+                        offset: true,
+                        grid: {
+                            offset: false
+                        }
                     },
                     y2: {
                         type: 'linear',
@@ -105,13 +105,16 @@ class PlotManager {
                             text: 'Stimulus Current (μA/cm²)'
                         },
                         grid: {
-                            drawOnChartArea: false
+                            drawOnChartArea: false,
+                            offset: false
                         },
-                        grace: '5%',
-                        beginAtZero: false,
-                        adapative: false,
-                        suggestedMin: this.stimulusYMin,
-                        suggestedMax: this.stimulusYMax
+                        offset: true
+                    }
+                },
+                layout: {
+                    padding: {
+                        top: 10,
+                        bottom: 10
                     }
                 },
                 plugins: {
@@ -154,6 +157,7 @@ class PlotManager {
                 responsive: true,
                 maintainAspectRatio: false,
                 animation: false,
+                resizeDelay: 0,
                 scales: {
                     x: {
                         type: 'linear',
@@ -178,11 +182,16 @@ class PlotManager {
                         ticks: {
                             stepSize: 0.2
                         },
-                        grace: '5%',
-                        beginAtZero: true,
-                        adapative: false,
-                        suggestedMin: this.gateYMin,
-                        suggestedMax: this.gateYMax
+                        offset: true,
+                        grid: {
+                            offset: false
+                        }
+                    }
+                },
+                layout: {
+                    padding: {
+                        top: 10,
+                        bottom: 10
                     }
                 },
                 plugins: {
@@ -193,6 +202,28 @@ class PlotManager {
                 }
             }
         });
+
+        // Add resize observer to handle layout changes
+        const resizeObserver = new ResizeObserver(entries => {
+            for (let entry of entries) {
+                const canvas = entry.target;
+                const chart = canvas.id === this.voltageCanvasId ? this.voltageChart : this.gateKineticsChart;
+                
+                if (chart) {
+                    // Force chart to use container dimensions
+                    canvas.style.width = '100%';
+                    canvas.style.height = '300px'; // Match the height from CSS
+                    
+                    // Update chart with animation disabled
+                    chart.resize();
+                    chart.update('none');
+                }
+            }
+        });
+
+        // Observe both canvases
+        resizeObserver.observe(document.getElementById(voltageCanvasId));
+        resizeObserver.observe(document.getElementById(gateKineticsCanvasId));
     }
 
     // Reset plots to default view

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -10,8 +10,6 @@ class PlotManager {
             'g_K (uS)', 'I_leak (uA)', 'blank'
         ];
         this.selectedVars = ['m', 'h', 'n'];
-        this.defaultYMin = -100;
-        this.defaultYMax = 60;
         this.defaultXMin = 0;
         this.defaultXMax = 50;
         this.windowSize = 50;
@@ -20,153 +18,86 @@ class PlotManager {
         this.updateCount = 0;
         this.updateThreshold = 4;
 
-        // Fixed y-axis ranges
-        this.voltageYMin = -100;
-        this.voltageYMax = 60;
-        this.stimulusYMin = -20;
-        this.stimulusYMax = 20;
-        this.gateYMin = 0;
-        this.gateYMax = 1;
+        // Fixed y-axis ranges (these are the source of truth)
+        this.voltageYConfig = {
+            type: 'linear',
+            min: -100,
+            max: 60,
+            title: { display: true, text: 'Membrane Potential (mV)' },
+            ticks: { stepSize: 20 },
+        };
+        this.stimulusYConfig = {
+            type: 'linear',
+            position: 'right',
+            min: -20,
+            max: 20,
+            title: { display: true, text: 'Stimulus Current (μA/cm²)' },
+            grid: { drawOnChartArea: false },
+        };
+        this.gateYConfig = {
+            type: 'linear',
+            min: 0,
+            max: 1,
+            title: { display: true, text: 'Gate Value' },
+            ticks: { stepSize: 0.2 },
+        };
     }
 
     initPlots(voltageCanvasId, gateKineticsCanvasId) {
         this.voltageCanvasId = voltageCanvasId;
         this.gateKineticsCanvasId = gateKineticsCanvasId;
 
-        const commonOptions = {
-            responsive: false,
-            maintainAspectRatio: false,
-            animation: false,
-            plugins: {
-                legend: {
-                    display: true,
-                    position: 'top'
-                }
-            }
+        const commonXAxisConfig = {
+            type: 'linear',
+            min: this.defaultXMin,
+            max: this.defaultXMax,
+            title: { display: true, text: 'Time (ms)' },
+            ticks: { stepSize: 10 },
         };
-        
-        // Initialize voltage plot
+
         const voltageCtx = document.getElementById(voltageCanvasId).getContext('2d');
         this.voltageChart = new Chart(voltageCtx, {
             type: 'line',
             data: {
                 labels: [],
                 datasets: [
-                    {
-                        label: 'Membrane Potential (mV)',
-                        data: [],
-                        borderColor: 'rgb(255, 0, 0)',
-                        tension: 0.1,
-                        yAxisID: 'y'
-                    },
-                    {
-                        label: 'Stimulus Current (μA/cm²)',
-                        data: [],
-                        borderColor: 'rgb(128, 0, 128)',
-                        tension: 0.1,
-                        yAxisID: 'y2'
-                    }
+                    { label: 'Membrane Potential (mV)', data: [], borderColor: 'rgb(255, 0, 0)', tension: 0.1, yAxisID: 'y' },
+                    { label: 'Stimulus Current (μA/cm²)', data: [], borderColor: 'rgb(128, 0, 128)', tension: 0.1, yAxisID: 'y2' }
                 ]
             },
             options: {
-                ...commonOptions,
+                responsive: false,
+                maintainAspectRatio: false,
+                animation: false,
                 scales: {
-                    x: {
-                        type: 'linear',
-                        min: this.defaultXMin,
-                        max: this.defaultXMax,
-                        title: {
-                            display: true,
-                            text: 'Time (ms)'
-                        },
-                        ticks: {
-                            stepSize: 10
-                        }
-                    },
-                    y: {
-                        type: 'linear',
-                        min: this.voltageYMin,
-                        max: this.voltageYMax,
-                        title: {
-                            display: true,
-                            text: 'Membrane Potential (mV)'
-                        },
-                        ticks: {
-                            stepSize: 20
-                        }
-                    },
-                    y2: {
-                        type: 'linear',
-                        position: 'right',
-                        min: this.stimulusYMin,
-                        max: this.stimulusYMax,
-                        title: {
-                            display: true,
-                            text: 'Stimulus Current (μA/cm²)'
-                        },
-                        grid: {
-                            drawOnChartArea: false
-                        }
-                    }
-                }
+                    x: commonXAxisConfig,
+                    y: { ...this.voltageYConfig },
+                    y2: { ...this.stimulusYConfig },
+                },
+                plugins: { legend: { display: true, position: 'top' } }
             }
         });
 
-        // Initialize gate kinetics plot
         const gateKineticsCtx = document.getElementById(gateKineticsCanvasId).getContext('2d');
         this.gateKineticsChart = new Chart(gateKineticsCtx, {
             type: 'line',
             data: {
                 labels: [],
                 datasets: [
-                    {
-                        label: 'm (Na+ activation)',
-                        data: [],
-                        borderColor: 'rgb(255, 255, 0)',
-                        tension: 0.1
-                    },
-                    {
-                        label: 'h (Na+ inactivation)',
-                        data: [],
-                        borderColor: 'rgb(0, 255, 0)',
-                        tension: 0.1
-                    },
-                    {
-                        label: 'n (K+ activation)',
-                        data: [],
-                        borderColor: 'rgb(0, 255, 255)',
-                        tension: 0.1
-                    }
+                    { label: 'm (Na+ activation)', data: [], borderColor: 'rgb(255, 255, 0)', tension: 0.1 },
+                    { label: 'h (Na+ inactivation)', data: [], borderColor: 'rgb(0, 255, 0)', tension: 0.1 },
+                    { label: 'n (K+ activation)', data: [], borderColor: 'rgb(0, 255, 255)', tension: 0.1 }
                 ]
             },
             options: {
-                ...commonOptions,
+                responsive: false,
+                maintainAspectRatio: false,
+                animation: false,
                 scales: {
-                    x: {
-                        type: 'linear',
-                        min: this.defaultXMin,
-                        max: this.defaultXMax,
-                        title: {
-                            display: true,
-                            text: 'Time (ms)'
-                        },
-                        ticks: {
-                            stepSize: 10
-                        }
-                    },
-                    y: {
-                        type: 'linear',
-                        min: this.gateYMin,
-                        max: this.gateYMax,
-                        title: {
-                            display: true,
-                            text: 'Gate Value'
-                        },
-                        ticks: {
-                            stepSize: 0.2
-                        }
-                    }
-                }
+                    x: commonXAxisConfig,
+                    y: { ...this.gateYConfig },
+                },
+                plugins: { legend: { display: true, position: 'top' } }
             }
         });
     }
@@ -179,7 +110,6 @@ class PlotManager {
             return;
         }
 
-        // Calculate stimulus current data
         const stimulusCurrent = data.time.map((t, i) => {
             let iStim = 0;
             if (data.stim1 && data.stim1.active && t >= data.stim1.startTime && t < data.stim1.startTime + data.stim1.duration) {
@@ -191,7 +121,6 @@ class PlotManager {
             return iStim;
         });
 
-        // Update data
         this.voltageChart.data.labels = data.time;
         this.voltageChart.data.datasets[0].data = data.voltage;
         this.voltageChart.data.datasets[1].data = stimulusCurrent;
@@ -201,119 +130,88 @@ class PlotManager {
         this.gateKineticsChart.data.datasets[1].data = data.gating.h;
         this.gateKineticsChart.data.datasets[2].data = data.gating.n;
 
-        // Handle x-axis sliding window
-        const currentMin = this.voltageChart.options.scales.x.min;
-        const currentMax = this.voltageChart.options.scales.x.max;
+        const currentXMin = this.voltageChart.options.scales.x.min;
+        const currentXMax = this.voltageChart.options.scales.x.max;
         const lastTime = data.time[data.time.length - 1] || 0;
 
-        if (lastTime > currentMax) {
-            const slideDistance = this.slideAmount;
-            const newMin = currentMin + slideDistance;
-            const newMax = currentMin + this.windowSize + slideDistance;
-            
+        if (lastTime > currentXMax) {
+            const newMin = currentXMin + this.slideAmount;
+            const newMax = currentXMin + this.windowSize + this.slideAmount;
             this.voltageChart.options.scales.x.min = newMin;
             this.voltageChart.options.scales.x.max = newMax;
             this.gateKineticsChart.options.scales.x.min = newMin;
             this.gateKineticsChart.options.scales.x.max = newMax;
         }
 
-        // Buffer management
         if (data.time.length > this.bufferSize) {
             const excess = data.time.length - this.bufferSize;
-            
             this.voltageChart.data.labels = data.time.slice(excess);
             this.voltageChart.data.datasets[0].data = data.voltage.slice(excess);
             this.voltageChart.data.datasets[1].data = stimulusCurrent.slice(excess);
-            
             this.gateKineticsChart.data.labels = data.time.slice(excess);
             this.gateKineticsChart.data.datasets[0].data = data.gating.m.slice(excess);
             this.gateKineticsChart.data.datasets[1].data = data.gating.h.slice(excess);
             this.gateKineticsChart.data.datasets[2].data = data.gating.n.slice(excess);
         }
+        
+        // Force Y axis configuration on every update
+        this.voltageChart.options.scales.y = { ...this.voltageYConfig };
+        this.voltageChart.options.scales.y2 = { ...this.stimulusYConfig };
+        this.gateKineticsChart.options.scales.y = { ...this.gateYConfig };
 
-        // Update both charts
         this.voltageChart.update('none');
         this.gateKineticsChart.update('none');
     }
 
     resetView() {
-        if (!this.voltageChart || !this.gateKineticsChart) return;
-        
-        // Reset voltage plot
-        const oldVoltageCanvas = document.getElementById(this.voltageCanvasId);
-        const voltageParent = oldVoltageCanvas.parentNode;
-        const voltageWidth = oldVoltageCanvas.width;
-        const voltageHeight = oldVoltageCanvas.height;
-        
-        this.voltageChart.destroy();
-        this.voltageChart = null;
-        oldVoltageCanvas.remove();
-        
+        if (this.voltageChart) this.voltageChart.destroy();
+        if (this.gateKineticsChart) this.gateKineticsChart.destroy();
+
+        // Re-create canvases because destroy removes them
+        const voltageParent = document.getElementById(this.voltageCanvasId).parentNode;
         const newVoltageCanvas = document.createElement('canvas');
         newVoltageCanvas.id = this.voltageCanvasId;
-        newVoltageCanvas.width = voltageWidth;
-        newVoltageCanvas.height = voltageHeight;
+        newVoltageCanvas.width = 800; // Match CSS
+        newVoltageCanvas.height = 300; // Match CSS
+        voltageParent.innerHTML = ''; // Clear old canvas if any remnants
         voltageParent.appendChild(newVoltageCanvas);
 
-        // Reset gate kinetics plot
-        const oldGateCanvas = document.getElementById(this.gateKineticsCanvasId);
-        const gateParent = oldGateCanvas.parentNode;
-        const gateWidth = oldGateCanvas.width;
-        const gateHeight = oldGateCanvas.height;
-        
-        this.gateKineticsChart.destroy();
-        this.gateKineticsChart = null;
-        oldGateCanvas.remove();
-        
+        const gateParent = document.getElementById(this.gateKineticsCanvasId).parentNode;
         const newGateCanvas = document.createElement('canvas');
         newGateCanvas.id = this.gateKineticsCanvasId;
-        newGateCanvas.width = gateWidth;
-        newGateCanvas.height = gateHeight;
+        newGateCanvas.width = 800; // Match CSS
+        newGateCanvas.height = 300; // Match CSS
+        gateParent.innerHTML = ''; // Clear old canvas
         gateParent.appendChild(newGateCanvas);
 
-        // Reinitialize both plots
         this.initPlots(this.voltageCanvasId, this.gateKineticsCanvasId);
-        
-        // Reset all internal state
-        this.updateCount = 0;
     }
 
     setXAxisLimits(center, width) {
         if (!this.voltageChart || !this.gateKineticsChart) return;
-        
-        const min = Math.max(0, center - width/2);
-        const max = center + width/2;
-        
-        this.voltageChart.options.scales.x.min = min;
-        this.voltageChart.options.scales.x.max = max;
-        this.gateKineticsChart.options.scales.x.min = min;
-        this.gateKineticsChart.options.scales.x.max = max;
-        
+        const newMin = Math.max(0, center - width / 2);
+        const newMax = center + width / 2;
+        this.voltageChart.options.scales.x.min = newMin;
+        this.voltageChart.options.scales.x.max = newMax;
+        this.gateKineticsChart.options.scales.x.min = newMin;
+        this.gateKineticsChart.options.scales.x.max = newMax;
         this.voltageChart.update('none');
         this.gateKineticsChart.update('none');
     }
 
-    resizePlot(factor) {
+    resizePlot(factor) { // This might not be needed with responsive:false
         if (!this.voltageChart || !this.gateKineticsChart) return;
-        
         const currentMin = this.voltageChart.options.scales.x.min;
         const currentMax = this.voltageChart.options.scales.x.max;
         const currentWidth = currentMax - currentMin;
         const center = (currentMax + currentMin) / 2;
-        
         const newWidth = factor > 0 ? currentWidth * 1.5 : currentWidth / 1.5;
         this.setXAxisLimits(center, newWidth);
     }
 
     destroy() {
-        if (this.voltageChart) {
-            this.voltageChart.destroy();
-            this.voltageChart = null;
-        }
-        if (this.gateKineticsChart) {
-            this.gateKineticsChart.destroy();
-            this.gateKineticsChart = null;
-        }
+        if (this.voltageChart) this.voltageChart.destroy();
+        if (this.gateKineticsChart) this.gateKineticsChart.destroy();
     }
 }
 

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -72,32 +72,37 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 10
-                        }
+                        },
+                        bounds: 'data'
                     },
                     y: {
                         type: 'linear',
-                        min: -100,
-                        max: 60,
+                        min: this.voltageYMin,
+                        max: this.voltageYMax,
                         title: {
                             display: true,
                             text: 'Membrane Potential (mV)'
                         },
                         ticks: {
                             stepSize: 20
-                        }
+                        },
+                        bounds: 'data',
+                        beginAtZero: false
                     },
                     y2: {
                         type: 'linear',
                         position: 'right',
-                        min: -20,
-                        max: 20,
+                        min: this.stimulusYMin,
+                        max: this.stimulusYMax,
                         title: {
                             display: true,
                             text: 'Stimulus Current (μA/cm²)'
                         },
                         grid: {
                             drawOnChartArea: false
-                        }
+                        },
+                        bounds: 'data',
+                        beginAtZero: false
                     }
                 },
                 plugins: {
@@ -151,19 +156,22 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 10
-                        }
+                        },
+                        bounds: 'data'
                     },
                     y: {
                         type: 'linear',
-                        min: 0,
-                        max: 1,
+                        min: this.gateYMin,
+                        max: this.gateYMax,
                         title: {
                             display: true,
                             text: 'Gate Value'
                         },
                         ticks: {
                             stepSize: 0.2
-                        }
+                        },
+                        bounds: 'data',
+                        beginAtZero: true
                     }
                 },
                 plugins: {
@@ -293,7 +301,57 @@ class PlotManager {
             this.gateKineticsChart.data.datasets[2].data = data.gating.n.slice(excess);
         }
 
-        // Update both charts
+        // Ensure y-axis ranges are fixed
+        this.voltageChart.options.scales.y = {
+            type: 'linear',
+            min: this.voltageYMin,
+            max: this.voltageYMax,
+            title: {
+                display: true,
+                text: 'Membrane Potential (mV)'
+            },
+            ticks: {
+                stepSize: 20
+            },
+            bounds: 'data',
+            beginAtZero: false
+        };
+
+        this.voltageChart.options.scales.y2 = {
+            type: 'linear',
+            position: 'right',
+            min: this.stimulusYMin,
+            max: this.stimulusYMax,
+            title: {
+                display: true,
+                text: 'Stimulus Current (μA/cm²)'
+            },
+            grid: {
+                drawOnChartArea: false
+            },
+            bounds: 'data',
+            beginAtZero: false
+        };
+
+        this.gateKineticsChart.options.scales.y = {
+            type: 'linear',
+            min: this.gateYMin,
+            max: this.gateYMax,
+            title: {
+                display: true,
+                text: 'Gate Value'
+            },
+            ticks: {
+                stepSize: 0.2
+            },
+            bounds: 'data',
+            beginAtZero: true
+        };
+
+        // Update both charts with animation disabled and immediate mode
+        this.voltageChart.options.animation = false;
+        this.gateKineticsChart.options.animation = false;
+        
         this.voltageChart.update('none');
         this.gateKineticsChart.update('none');
     }

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -69,21 +69,28 @@ class PlotManager {
                         title: {
                             display: true,
                             text: 'Time (ms)'
+                        },
+                        ticks: {
+                            stepSize: 10
                         }
                     },
                     y: {
-                        min: this.voltageYMin,
-                        max: this.voltageYMax,
+                        type: 'linear',
+                        min: -100,
+                        max: 60,
                         title: {
                             display: true,
                             text: 'Membrane Potential (mV)'
+                        },
+                        ticks: {
+                            stepSize: 20
                         }
                     },
                     y2: {
                         type: 'linear',
                         position: 'right',
-                        min: this.stimulusYMin,
-                        max: this.stimulusYMax,
+                        min: -20,
+                        max: 20,
                         title: {
                             display: true,
                             text: 'Stimulus Current (μA/cm²)'
@@ -141,14 +148,21 @@ class PlotManager {
                         title: {
                             display: true,
                             text: 'Time (ms)'
+                        },
+                        ticks: {
+                            stepSize: 10
                         }
                     },
                     y: {
-                        min: this.gateYMin,
-                        max: this.gateYMax,
+                        type: 'linear',
+                        min: 0,
+                        max: 1,
                         title: {
                             display: true,
                             text: 'Gate Value'
+                        },
+                        ticks: {
+                            stepSize: 0.2
                         }
                     }
                 },
@@ -252,14 +266,9 @@ class PlotManager {
 
         // Check if we need to slide the window
         if (lastTime > currentMax) {
-            const timeOverflow = lastTime - currentMax;
-            const slidesNeeded = Math.ceil(timeOverflow / this.slideAmount);
             const slideDistance = this.slideAmount;
-            
             const newMin = currentMin + slideDistance;
             const newMax = currentMin + this.windowSize + slideDistance;
-            
-            console.log(`Sliding window by ${slideDistance}ms:`, newMin, 'to', newMax);
             
             // Update both plots' x-axis
             this.voltageChart.options.scales.x.min = newMin;

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -19,6 +19,14 @@ class PlotManager {
         this.bufferSize = 5000;
         this.updateCount = 0;
         this.updateThreshold = 4;
+
+        // Fixed y-axis ranges
+        this.voltageYMin = -100;
+        this.voltageYMax = 60;
+        this.stimulusYMin = -20;
+        this.stimulusYMax = 20;
+        this.gateYMin = 0;
+        this.gateYMax = 1;
     }
 
     // Initialize both plots
@@ -64,8 +72,8 @@ class PlotManager {
                         }
                     },
                     y: {
-                        min: this.defaultYMin,
-                        max: this.defaultYMax,
+                        min: this.voltageYMin,
+                        max: this.voltageYMax,
                         title: {
                             display: true,
                             text: 'Membrane Potential (mV)'
@@ -74,8 +82,8 @@ class PlotManager {
                     y2: {
                         type: 'linear',
                         position: 'right',
-                        min: -20,
-                        max: 20,
+                        min: this.stimulusYMin,
+                        max: this.stimulusYMax,
                         title: {
                             display: true,
                             text: 'Stimulus Current (μA/cm²)'
@@ -136,8 +144,8 @@ class PlotManager {
                         }
                     },
                     y: {
-                        min: 0,
-                        max: 1,
+                        min: this.gateYMin,
+                        max: this.gateYMax,
                         title: {
                             display: true,
                             text: 'Gate Value'
@@ -258,19 +266,6 @@ class PlotManager {
             this.voltageChart.options.scales.x.max = newMax;
             this.gateKineticsChart.options.scales.x.min = newMin;
             this.gateKineticsChart.options.scales.x.max = newMax;
-        }
-
-        // Auto-adjust voltage y-axis if data extends beyond current view
-        const voltages = data.voltage;
-        if (voltages.length > 0) {
-            const minV = Math.min(...voltages);
-            const maxV = Math.max(...voltages);
-            if (minV < this.voltageChart.options.scales.y.min) {
-                this.voltageChart.options.scales.y.min = Math.floor(minV / 20) * 20;
-            }
-            if (maxV > this.voltageChart.options.scales.y.max) {
-                this.voltageChart.options.scales.y.max = Math.ceil(maxV / 20) * 20;
-            }
         }
 
         // Keep data buffer at reasonable size

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -27,16 +27,23 @@ class PlotManager {
         this.stimulusYMax = 20;
         this.gateYMin = 0;
         this.gateYMax = 1;
-
-        // Add debug properties
-        this.lastVoltageYRange = null;
-        this.lastGateYRange = null;
     }
 
-    // Initialize both plots
     initPlots(voltageCanvasId, gateKineticsCanvasId) {
         this.voltageCanvasId = voltageCanvasId;
         this.gateKineticsCanvasId = gateKineticsCanvasId;
+
+        const commonOptions = {
+            responsive: false,
+            maintainAspectRatio: false,
+            animation: false,
+            plugins: {
+                legend: {
+                    display: true,
+                    position: 'top'
+                }
+            }
+        };
         
         // Initialize voltage plot
         const voltageCtx = document.getElementById(voltageCanvasId).getContext('2d');
@@ -62,10 +69,7 @@ class PlotManager {
                 ]
             },
             options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                animation: false,
-                resizeDelay: 0,
+                ...commonOptions,
                 scales: {
                     x: {
                         type: 'linear',
@@ -89,10 +93,6 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 20
-                        },
-                        offset: true,
-                        grid: {
-                            offset: false
                         }
                     },
                     y2: {
@@ -105,22 +105,8 @@ class PlotManager {
                             text: 'Stimulus Current (μA/cm²)'
                         },
                         grid: {
-                            drawOnChartArea: false,
-                            offset: false
-                        },
-                        offset: true
-                    }
-                },
-                layout: {
-                    padding: {
-                        top: 10,
-                        bottom: 10
-                    }
-                },
-                plugins: {
-                    legend: {
-                        display: true,
-                        position: 'top'
+                            drawOnChartArea: false
+                        }
                     }
                 }
             }
@@ -154,10 +140,7 @@ class PlotManager {
                 ]
             },
             options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                animation: false,
-                resizeDelay: 0,
+                ...commonOptions,
                 scales: {
                     x: {
                         type: 'linear',
@@ -181,56 +164,80 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 0.2
-                        },
-                        offset: true,
-                        grid: {
-                            offset: false
                         }
                     }
-                },
-                layout: {
-                    padding: {
-                        top: 10,
-                        bottom: 10
-                    }
-                },
-                plugins: {
-                    legend: {
-                        display: true,
-                        position: 'top'
-                    }
                 }
             }
         });
-
-        // Add resize observer to handle layout changes
-        const resizeObserver = new ResizeObserver(entries => {
-            for (let entry of entries) {
-                const canvas = entry.target;
-                const chart = canvas.id === this.voltageCanvasId ? this.voltageChart : this.gateKineticsChart;
-                
-                if (chart) {
-                    // Force chart to use container dimensions
-                    canvas.style.width = '100%';
-                    canvas.style.height = '300px'; // Match the height from CSS
-                    
-                    // Update chart with animation disabled
-                    chart.resize();
-                    chart.update('none');
-                }
-            }
-        });
-
-        // Observe both canvases
-        resizeObserver.observe(document.getElementById(voltageCanvasId));
-        resizeObserver.observe(document.getElementById(gateKineticsCanvasId));
     }
 
-    // Reset plots to default view
-    resetView() {
+    updatePlots(data, isReset = false) {
         if (!this.voltageChart || !this.gateKineticsChart) return;
 
-        console.log('Starting charts reset...');
+        if (isReset) {
+            this.resetView();
+            return;
+        }
+
+        // Calculate stimulus current data
+        const stimulusCurrent = data.time.map((t, i) => {
+            let iStim = 0;
+            if (data.stim1 && data.stim1.active && t >= data.stim1.startTime && t < data.stim1.startTime + data.stim1.duration) {
+                iStim += data.stim1.amplitude;
+            }
+            if (data.stim2 && data.stim2.active && t >= data.stim2.startTime && t < data.stim2.startTime + data.stim2.duration) {
+                iStim += data.stim2.amplitude;
+            }
+            return iStim;
+        });
+
+        // Update data
+        this.voltageChart.data.labels = data.time;
+        this.voltageChart.data.datasets[0].data = data.voltage;
+        this.voltageChart.data.datasets[1].data = stimulusCurrent;
+
+        this.gateKineticsChart.data.labels = data.time;
+        this.gateKineticsChart.data.datasets[0].data = data.gating.m;
+        this.gateKineticsChart.data.datasets[1].data = data.gating.h;
+        this.gateKineticsChart.data.datasets[2].data = data.gating.n;
+
+        // Handle x-axis sliding window
+        const currentMin = this.voltageChart.options.scales.x.min;
+        const currentMax = this.voltageChart.options.scales.x.max;
+        const lastTime = data.time[data.time.length - 1] || 0;
+
+        if (lastTime > currentMax) {
+            const slideDistance = this.slideAmount;
+            const newMin = currentMin + slideDistance;
+            const newMax = currentMin + this.windowSize + slideDistance;
+            
+            this.voltageChart.options.scales.x.min = newMin;
+            this.voltageChart.options.scales.x.max = newMax;
+            this.gateKineticsChart.options.scales.x.min = newMin;
+            this.gateKineticsChart.options.scales.x.max = newMax;
+        }
+
+        // Buffer management
+        if (data.time.length > this.bufferSize) {
+            const excess = data.time.length - this.bufferSize;
+            
+            this.voltageChart.data.labels = data.time.slice(excess);
+            this.voltageChart.data.datasets[0].data = data.voltage.slice(excess);
+            this.voltageChart.data.datasets[1].data = stimulusCurrent.slice(excess);
+            
+            this.gateKineticsChart.data.labels = data.time.slice(excess);
+            this.gateKineticsChart.data.datasets[0].data = data.gating.m.slice(excess);
+            this.gateKineticsChart.data.datasets[1].data = data.gating.h.slice(excess);
+            this.gateKineticsChart.data.datasets[2].data = data.gating.n.slice(excess);
+        }
+
+        // Update both charts
+        this.voltageChart.update('none');
+        this.gateKineticsChart.update('none');
+    }
+
+    resetView() {
+        if (!this.voltageChart || !this.gateKineticsChart) return;
         
         // Reset voltage plot
         const oldVoltageCanvas = document.getElementById(this.voltageCanvasId);
@@ -269,238 +276,8 @@ class PlotManager {
         
         // Reset all internal state
         this.updateCount = 0;
-        
-        console.log('Charts reset complete');
     }
 
-    // Update both plots with new data
-    updatePlots(data, isReset = false) {
-        if (!this.voltageChart || !this.gateKineticsChart) return;
-
-        // If this is a reset, force window back to default position
-        if (isReset) {
-            console.log('Handling reset in updatePlots...');
-            this.resetView();
-            return;
-        }
-
-        console.log('Starting plot update...');
-
-        // Log current scales before any updates
-        const beforeScales = {
-            voltage: {
-                y: {
-                    min: this.voltageChart.options.scales.y.min,
-                    max: this.voltageChart.options.scales.y.max,
-                    actualMin: this.voltageChart.scales?.y?.min,
-                    actualMax: this.voltageChart.scales?.y?.max
-                },
-                y2: {
-                    min: this.voltageChart.options.scales.y2.min,
-                    max: this.voltageChart.options.scales.y2.max,
-                    actualMin: this.voltageChart.scales?.y2?.min,
-                    actualMax: this.voltageChart.scales?.y2?.max
-                }
-            },
-            gate: {
-                y: {
-                    min: this.gateKineticsChart.options.scales.y.min,
-                    max: this.gateKineticsChart.options.scales.y.max,
-                    actualMin: this.gateKineticsChart.scales?.y?.min,
-                    actualMax: this.gateKineticsChart.scales?.y?.max
-                }
-            }
-        };
-        console.log('Initial scales:', beforeScales);
-
-        // Calculate stimulus current data
-        const stimulusCurrent = data.time.map((t, i) => {
-            let iStim = 0;
-            if (data.stim1 && data.stim1.active && t >= data.stim1.startTime && t < data.stim1.startTime + data.stim1.duration) {
-                iStim += data.stim1.amplitude;
-            }
-            if (data.stim2 && data.stim2.active && t >= data.stim2.startTime && t < data.stim2.startTime + data.stim2.duration) {
-                iStim += data.stim2.amplitude;
-            }
-            return iStim;
-        });
-
-        // Log data ranges
-        const dataRanges = {
-            voltage: {
-                min: Math.min(...data.voltage),
-                max: Math.max(...data.voltage)
-            },
-            stimulus: {
-                min: Math.min(...stimulusCurrent),
-                max: Math.max(...stimulusCurrent)
-            },
-            gates: {
-                m: { min: Math.min(...data.gating.m), max: Math.max(...data.gating.m) },
-                h: { min: Math.min(...data.gating.h), max: Math.max(...data.gating.h) },
-                n: { min: Math.min(...data.gating.n), max: Math.max(...data.gating.n) }
-            }
-        };
-        console.log('Data ranges:', dataRanges);
-
-        // Update data
-        this.voltageChart.data.labels = data.time;
-        this.voltageChart.data.datasets[0].data = data.voltage;
-        this.voltageChart.data.datasets[1].data = stimulusCurrent;
-
-        this.gateKineticsChart.data.labels = data.time;
-        this.gateKineticsChart.data.datasets[0].data = data.gating.m;
-        this.gateKineticsChart.data.datasets[1].data = data.gating.h;
-        this.gateKineticsChart.data.datasets[2].data = data.gating.n;
-
-        // Handle x-axis sliding window
-        const currentMin = this.voltageChart.options.scales.x.min;
-        const currentMax = this.voltageChart.options.scales.x.max;
-        const lastTime = data.time[data.time.length - 1] || 0;
-
-        if (lastTime > currentMax) {
-            const slideDistance = this.slideAmount;
-            const newMin = currentMin + slideDistance;
-            const newMax = currentMin + this.windowSize + slideDistance;
-            
-            console.log('Sliding window:', { 
-                oldMin: currentMin, 
-                oldMax: currentMax, 
-                newMin, 
-                newMax,
-                lastDataPoint: lastTime 
-            });
-            
-            this.voltageChart.options.scales.x.min = newMin;
-            this.voltageChart.options.scales.x.max = newMax;
-            this.gateKineticsChart.options.scales.x.min = newMin;
-            this.gateKineticsChart.options.scales.x.max = newMax;
-        }
-
-        // Buffer management
-        if (data.time.length > this.bufferSize) {
-            const excess = data.time.length - this.bufferSize;
-            console.log('Trimming buffer:', {
-                totalPoints: data.time.length,
-                excess,
-                newSize: data.time.length - excess
-            });
-            
-            this.voltageChart.data.labels = data.time.slice(excess);
-            this.voltageChart.data.datasets[0].data = data.voltage.slice(excess);
-            this.voltageChart.data.datasets[1].data = stimulusCurrent.slice(excess);
-            
-            this.gateKineticsChart.data.labels = data.time.slice(excess);
-            this.gateKineticsChart.data.datasets[0].data = data.gating.m.slice(excess);
-            this.gateKineticsChart.data.datasets[1].data = data.gating.h.slice(excess);
-            this.gateKineticsChart.data.datasets[2].data = data.gating.n.slice(excess);
-        }
-
-        // Explicitly set scale options before update
-        this.voltageChart.options.scales.y = {
-            type: 'linear',
-            min: this.voltageYMin,
-            max: this.voltageYMax,
-            title: {
-                display: true,
-                text: 'Membrane Potential (mV)'
-            },
-            ticks: {
-                stepSize: 20
-            }
-        };
-
-        this.voltageChart.options.scales.y2 = {
-            type: 'linear',
-            position: 'right',
-            min: this.stimulusYMin,
-            max: this.stimulusYMax,
-            title: {
-                display: true,
-                text: 'Stimulus Current (μA/cm²)'
-            },
-            grid: {
-                drawOnChartArea: false
-            }
-        };
-
-        this.gateKineticsChart.options.scales.y = {
-            type: 'linear',
-            min: this.gateYMin,
-            max: this.gateYMax,
-            title: {
-                display: true,
-                text: 'Gate Value'
-            },
-            ticks: {
-                stepSize: 0.2
-            }
-        };
-
-        // Update both charts
-        this.voltageChart.options.animation = false;
-        this.gateKineticsChart.options.animation = false;
-        
-        console.log('Updating charts...');
-        this.voltageChart.update('none');
-        this.gateKineticsChart.update('none');
-
-        // Check if scales changed after update
-        const afterScales = {
-            voltage: {
-                y: {
-                    min: this.voltageChart.options.scales.y.min,
-                    max: this.voltageChart.options.scales.y.max,
-                    actualMin: this.voltageChart.scales?.y?.min,
-                    actualMax: this.voltageChart.scales?.y?.max
-                },
-                y2: {
-                    min: this.voltageChart.options.scales.y2.min,
-                    max: this.voltageChart.options.scales.y2.max,
-                    actualMin: this.voltageChart.scales?.y2?.min,
-                    actualMax: this.voltageChart.scales?.y2?.max
-                }
-            },
-            gate: {
-                y: {
-                    min: this.gateKineticsChart.options.scales.y.min,
-                    max: this.gateKineticsChart.options.scales.y.max,
-                    actualMin: this.gateKineticsChart.scales?.y?.min,
-                    actualMax: this.gateKineticsChart.scales?.y?.max
-                }
-            }
-        };
-
-        // Compare scales and log changes
-        const scalesChanged = JSON.stringify(beforeScales) !== JSON.stringify(afterScales);
-        if (scalesChanged) {
-            console.log('⚠️ Scale change detected!');
-            console.log('Before:', beforeScales);
-            console.log('After:', afterScales);
-            
-            // Check which specific scales changed
-            if (beforeScales.voltage.y.min !== afterScales.voltage.y.min || 
-                beforeScales.voltage.y.max !== afterScales.voltage.y.max) {
-                console.log('Voltage Y scale changed');
-            }
-            if (beforeScales.voltage.y2.min !== afterScales.voltage.y2.min || 
-                beforeScales.voltage.y2.max !== afterScales.voltage.y2.max) {
-                console.log('Stimulus Y scale changed');
-            }
-            if (beforeScales.gate.y.min !== afterScales.gate.y.min || 
-                beforeScales.gate.y.max !== afterScales.gate.y.max) {
-                console.log('Gate Y scale changed');
-            }
-        }
-
-        // Store current ranges for next comparison
-        this.lastVoltageYRange = afterScales.voltage;
-        this.lastGateYRange = afterScales.gate;
-        
-        console.log('Plot update complete');
-    }
-
-    // Set the x-axis limits for both plots
     setXAxisLimits(center, width) {
         if (!this.voltageChart || !this.gateKineticsChart) return;
         
@@ -516,7 +293,6 @@ class PlotManager {
         this.gateKineticsChart.update('none');
     }
 
-    // Resize both plots
     resizePlot(factor) {
         if (!this.voltageChart || !this.gateKineticsChart) return;
         
@@ -529,7 +305,6 @@ class PlotManager {
         this.setXAxisLimits(center, newWidth);
     }
 
-    // Destroy both plots
     destroy() {
         if (this.voltageChart) {
             this.voltageChart.destroy();

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -72,8 +72,7 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 10
-                        },
-                        bounds: 'data'
+                        }
                     },
                     y: {
                         type: 'linear',
@@ -86,8 +85,11 @@ class PlotManager {
                         ticks: {
                             stepSize: 20
                         },
-                        bounds: 'data',
-                        beginAtZero: false
+                        grace: '5%',
+                        beginAtZero: false,
+                        adapative: false,
+                        suggestedMin: this.voltageYMin,
+                        suggestedMax: this.voltageYMax
                     },
                     y2: {
                         type: 'linear',
@@ -101,8 +103,11 @@ class PlotManager {
                         grid: {
                             drawOnChartArea: false
                         },
-                        bounds: 'data',
-                        beginAtZero: false
+                        grace: '5%',
+                        beginAtZero: false,
+                        adapative: false,
+                        suggestedMin: this.stimulusYMin,
+                        suggestedMax: this.stimulusYMax
                     }
                 },
                 plugins: {
@@ -156,8 +161,7 @@ class PlotManager {
                         },
                         ticks: {
                             stepSize: 10
-                        },
-                        bounds: 'data'
+                        }
                     },
                     y: {
                         type: 'linear',
@@ -170,8 +174,11 @@ class PlotManager {
                         ticks: {
                             stepSize: 0.2
                         },
-                        bounds: 'data',
-                        beginAtZero: true
+                        grace: '5%',
+                        beginAtZero: true,
+                        adapative: false,
+                        suggestedMin: this.gateYMin,
+                        suggestedMax: this.gateYMax
                     }
                 },
                 plugins: {
@@ -313,8 +320,11 @@ class PlotManager {
             ticks: {
                 stepSize: 20
             },
-            bounds: 'data',
-            beginAtZero: false
+            grace: '5%',
+            beginAtZero: false,
+            adapative: false,
+            suggestedMin: this.voltageYMin,
+            suggestedMax: this.voltageYMax
         };
 
         this.voltageChart.options.scales.y2 = {
@@ -329,8 +339,11 @@ class PlotManager {
             grid: {
                 drawOnChartArea: false
             },
-            bounds: 'data',
-            beginAtZero: false
+            grace: '5%',
+            beginAtZero: false,
+            adapative: false,
+            suggestedMin: this.stimulusYMin,
+            suggestedMax: this.stimulusYMax
         };
 
         this.gateKineticsChart.options.scales.y = {
@@ -344,14 +357,18 @@ class PlotManager {
             ticks: {
                 stepSize: 0.2
             },
-            bounds: 'data',
-            beginAtZero: true
+            grace: '5%',
+            beginAtZero: true,
+            adapative: false,
+            suggestedMin: this.gateYMin,
+            suggestedMax: this.gateYMax
         };
 
         // Update both charts with animation disabled and immediate mode
         this.voltageChart.options.animation = false;
         this.gateKineticsChart.options.animation = false;
         
+        // Force a complete redraw
         this.voltageChart.update('none');
         this.gateKineticsChart.update('none');
     }

--- a/docs/js/plot-manager.js
+++ b/docs/js/plot-manager.js
@@ -47,6 +47,19 @@ class PlotManager {
         this.voltageCanvasId = voltageCanvasId;
         this.gateKineticsCanvasId = gateKineticsCanvasId;
 
+        const voltageCanvas = document.getElementById(voltageCanvasId);
+        const gateKineticsCanvas = document.getElementById(gateKineticsCanvasId);
+
+        // Explicitly set canvas dimensions from CSS or desired fixed size
+        // Ensure this matches your CSS, or set your desired fixed size directly here.
+        const canvasWidth = 800; // As per your CSS
+        const canvasHeight = 300; // As per your CSS
+
+        voltageCanvas.width = canvasWidth;
+        voltageCanvas.height = canvasHeight;
+        gateKineticsCanvas.width = canvasWidth;
+        gateKineticsCanvas.height = canvasHeight;
+
         const commonXAxisConfig = {
             type: 'linear',
             min: this.defaultXMin,

--- a/docs/js/simulator.js
+++ b/docs/js/simulator.js
@@ -16,7 +16,9 @@ class Simulator {
                 m: [],
                 h: [],
                 n: []
-            }
+            },
+            stim1: this.stim1,
+            stim2: this.stim2
         };
         this.bufferSize = 2000;
         this.onUpdate = null;
@@ -160,6 +162,7 @@ class Simulator {
     applyStim1() {
         this.stim1.active = true;
         this.stim1.startTime = this.model.time;
+        this.dataBuffer.stim1 = this.stim1;  // Update stim1 in data buffer
         
         // Start simulation if not running
         if (!this.running) {
@@ -177,6 +180,7 @@ class Simulator {
     applyStim2() {
         this.stim2.active = true;
         this.stim2.startTime = this.model.time;
+        this.dataBuffer.stim2 = this.stim2;  // Update stim2 in data buffer
         
         // Start simulation if not running
         if (!this.running) {
@@ -204,6 +208,10 @@ class Simulator {
             this.model.reset();
             this.endTime = 0;
             
+            // Reset stimulus states
+            this.stim1.active = false;
+            this.stim2.active = false;
+            
             // Clear all data buffers
             this.dataBuffer = {
                 time: [0],  // Start with initial time point
@@ -215,7 +223,9 @@ class Simulator {
                     m: [this.model.m],
                     h: [this.model.h],
                     n: [this.model.n]
-                }
+                },
+                stim1: this.stim1,
+                stim2: this.stim2
             };
             
             // Store initial state

--- a/docs/js/ui-controller.js
+++ b/docs/js/ui-controller.js
@@ -13,7 +13,12 @@ class UIController {
 
     // Initialize the UI
     init() {
-        this.initializePlots();
+        // Delay plot initialization slightly to ensure DOM and CSS are ready
+        requestAnimationFrame(() => {
+            this.initializePlots();
+            // Other initializations that depend on plots can also be moved here if necessary
+        });
+        
         this.setupEventListeners();
         this.setupTabSystem();
         this.loadInitialParameters();

--- a/docs/js/ui-controller.js
+++ b/docs/js/ui-controller.js
@@ -8,7 +8,7 @@ class UIController {
         this.activeTab = 'membrane';
         
         // Bind simulator update callback
-        this.simulator.onUpdate = (data, isReset) => this.plotManager.updatePlot(data, isReset);
+        this.simulator.onUpdate = (data, isReset) => this.plotManager.updatePlots(data, isReset);
     }
 
     // Initialize the UI
@@ -21,7 +21,7 @@ class UIController {
 
     // Initialize plots
     initializePlots() {
-        this.plotManager.initMainPlot('plotCanvas');
+        this.plotManager.initPlots('plotCanvas', 'gateKineticsCanvas');
     }
 
     // Set up event listeners for all UI elements

--- a/docs/js/ui-controller.js
+++ b/docs/js/ui-controller.js
@@ -26,6 +26,21 @@ class UIController {
 
     // Initialize plots
     initializePlots() {
+        const voltageCanvas = document.getElementById('plotCanvas');
+        const gateKineticsCanvas = document.getElementById('gateKineticsCanvas');
+
+        const canvasWidth = 800; // As per your CSS
+        const canvasHeight = 300; // As per your CSS
+
+        if (voltageCanvas) {
+            voltageCanvas.width = canvasWidth;
+            voltageCanvas.height = canvasHeight;
+        }
+        if (gateKineticsCanvas) {
+            gateKineticsCanvas.width = canvasWidth;
+            gateKineticsCanvas.height = canvasHeight;
+        }
+        // Now that canvas attributes are set, initialize the plots
         this.plotManager.initPlots('plotCanvas', 'gateKineticsCanvas');
     }
 


### PR DESCRIPTION
Created a dual-plot system:
Top plot: Membrane voltage (red) and stimulus current (purple)
Bottom plot: Gate kinetics (m in yellow, h in green, n in cyan)

Encountered and fixed several issues:
Initial scaling bug where plots would "squish" from bottom to top:
Removed auto-scaling logic
Implemented fixed y-axis ranges
Added specific tick intervals
Canvas sizing inconsistency:
Moved canvas dimensions to class properties:
Apply to hh-model.js
Ensured consistent canvas sizing by setting both canvas and style dimensions:
Apply to hh-model.js
Removed CSS-based dimensions to avoid conflicts

The final solution ensures:
Proper plot sizing on both the initial load and after reset
Synchronized x-axis scrolling between plots
Fixed y-axis ranges with appropriate scales for each variable
Clear visual distinction between different data series
Efficient data handling with buffer management
The plots now correctly display:
Top Plot:
Membrane voltage (-100 to 60 mV) in red
Stimulus current (-20 to 20 μA/cm²) in purple
Bottom Plot:
m gate (Na+ activation) in yellow
h gate (Na+ inactivation) in green
n gate (K+ activation) in cyan